### PR TITLE
Fix for issue#9 and also a base class namespace issue.

### DIFF
--- a/Framework/bin/ODatagenBinary/MacOSX10.7.sdk/Release/objc_baseClasses.xsl
+++ b/Framework/bin/ODatagenBinary/MacOSX10.7.sdk/Release/objc_baseClasses.xsl
@@ -116,21 +116,21 @@
 	</xsl:for-each>
 }
 <xsl:for-each select="schema_1_0:Property | schema_1_1:Property | schema_1_2:Property">
-@property ( nonatomic , <xsl:if test="@Type = 'Edm.String'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> ) NSString *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int32'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int16'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int64'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Binary'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSData *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Decimal'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.DateTime'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.DateTimeOffset'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Time'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Single'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Guid'">retain ,  getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSString *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Double'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Byte'">assign , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )Byte m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Boolean'">assign , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )ODataBool *m_</xsl:if>
-<xsl:if test="contains(@Type, $service_namespace)"><xsl:if test="contains(@Type,@ComplexType)"> retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )<xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="substring-after(@Type,concat($service_namespace, '.'))"/> *m_</xsl:if></xsl:if>
+@property ( nonatomic , <xsl:if test="@Type = 'Edm.String'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: ) NSString *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int32'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int16'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int64'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Binary'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSData *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Decimal'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.DateTime'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.DateTimeOffset'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Time'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Single'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Guid'">retain ,  getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSString *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Double'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Byte'">assign , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )Byte m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Boolean'">assign , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )ODataBool *m_</xsl:if>
+    <xsl:if test="contains(@Type, $service_namespace)"><xsl:if test="contains(@Type,@ComplexType)"> retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )<xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="substring-after(@Type,concat($service_namespace, '.'))"/> *m_</xsl:if></xsl:if>
 <xsl:value-of select="@Name"/>;</xsl:for-each>
 
 @end
@@ -203,25 +203,25 @@
 	</xsl:for-each>
 }
 <xsl:for-each select="schema_1_0:Property | schema_1_1:Property | schema_1_2:Property">
-@property ( nonatomic , <xsl:if test="@Type = 'Edm.String'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> ) NSString *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int32'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int16'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int64'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Binary'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSData *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Decimal'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.DateTime'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Single'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Guid'">retain ,  getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSString *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Double'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.DateTimeOffset'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Time'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Byte'">assign , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )Byte m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Boolean'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )ODataBool *m_</xsl:if>
-<xsl:if test="contains(@Type, $service_namespace)"><xsl:if test="contains(@Type,@ComplexType)"> retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )<xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="substring-after(@Type,concat($service_namespace, '.'))"/> *m_</xsl:if></xsl:if>
+@property ( nonatomic , <xsl:if test="@Type = 'Edm.String'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: ) NSString *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int32'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int16'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int64'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Binary'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSData *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Decimal'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.DateTime'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Single'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Guid'">retain ,  getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSString *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Double'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.DateTimeOffset'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Time'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Byte'">assign , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )Byte m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Boolean'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )ODataBool *m_</xsl:if>
+    <xsl:if test="contains(@Type, $service_namespace)"><xsl:if test="contains(@Type,@ComplexType)"> retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )<xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="substring-after(@Type,concat($service_namespace, '.'))"/> *m_</xsl:if></xsl:if>
 <xsl:value-of select="@Name"/>;</xsl:for-each>
 
 <xsl:for-each select="schema_1_0:NavigationProperty | schema_1_1:NavigationProperty | schema_1_2:NavigationProperty">
-@property ( nonatomic , retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSMutableArray *m_<xsl:value-of select="@Name"/>;</xsl:for-each>
+@property ( nonatomic , retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSMutableArray *m_<xsl:value-of select="@Name"/>;</xsl:for-each>
 
 + (id) Create<xsl:value-of select="@Name"/><xsl:if test="schema_1_0:Property[@Nullable = 'false'] | schema_1_1:Property[@Nullable = 'false'] | schema_1_2:Property[@Nullable = 'false']">With<xsl:for-each select="schema_1_0:Property[@Nullable = 'false'] | schema_1_1:Property[@Nullable = 'false'] | schema_1_2:Property[@Nullable = 'false']"><xsl:value-of select="translate(@Name, $uppercase, $smallcase)"/>:(<xsl:if test="@Type = 'Edm.String'">NSString *</xsl:if><xsl:if test="@Type = 'Edm.Int32'">NSNumber *</xsl:if><xsl:if test="@Type = 'Edm.Int16'">NSNumber *</xsl:if><xsl:if test="@Type = 'Edm.Int64'">NSNumber *</xsl:if>
 <xsl:if test="@Type = 'Edm.Binary'">NSData *</xsl:if>

--- a/Framework/bin/ODatagenBinary/MacOSX10.7.sdk/Release/objc_headers.xsl
+++ b/Framework/bin/ODatagenBinary/MacOSX10.7.sdk/Release/objc_headers.xsl
@@ -34,7 +34,7 @@
  * @FC_Criteria:NIL
  </xsl:if>
  */
-@interface <xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="@Name"/> : <xsl:choose><xsl:when test="@BaseType"><xsl:value-of select="substring-after(@BaseType, concat($service_namespace, '.'))"/></xsl:when><xsl:otherwise>ODataObject</xsl:otherwise></xsl:choose>
+@interface <xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="@Name"/> : <xsl:choose><xsl:when test="@BaseType"><xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="substring-after(@BaseType, concat($service_namespace, '.'))"/></xsl:when><xsl:otherwise>ODataObject</xsl:otherwise></xsl:choose>
 {
 	<xsl:for-each select="schema_1_0:Property | schema_1_1:Property | schema_1_2:Property">
 	/**
@@ -82,25 +82,25 @@
 	</xsl:for-each>
 }
 <xsl:for-each select="schema_1_0:Property | schema_1_1:Property | schema_1_2:Property">
-@property ( nonatomic , <xsl:if test="@Type = 'Edm.String'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> ) NSString *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int32'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int16'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Int64'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Binary'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSData *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Decimal'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.DateTime'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Single'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Guid'">retain ,  getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSString *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Double'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDecimalNumber *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.DateTimeOffset'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Time'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSDate *m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Byte'">assign , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )Byte m_</xsl:if>
-<xsl:if test="@Type = 'Edm.Boolean'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )ODataBool *m_</xsl:if>
-<xsl:if test="contains(@Type, $service_namespace)"><xsl:if test="contains(@Type,@ComplexType)"> retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )<xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="substring-after(@Type,concat($service_namespace, '.'))"/> *m_</xsl:if></xsl:if>
+@property ( nonatomic , <xsl:if test="@Type = 'Edm.String'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: ) NSString *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int32'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int16'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Int64'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Binary'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSData *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Decimal'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.DateTime'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Single'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Guid'">retain ,  getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSString *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Double'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDecimalNumber *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.DateTimeOffset'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Time'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSDate *m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Byte'">assign , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )Byte m_</xsl:if>
+    <xsl:if test="@Type = 'Edm.Boolean'">retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )ODataBool *m_</xsl:if>
+    <xsl:if test="contains(@Type, $service_namespace)"><xsl:if test="contains(@Type,@ComplexType)"> retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )<xsl:value-of select="$modified_service_namespace"/>_<xsl:value-of select="substring-after(@Type,concat($service_namespace, '.'))"/> *m_</xsl:if></xsl:if>
 <xsl:value-of select="@Name"/>;</xsl:for-each>
 
 <xsl:for-each select="schema_1_0:NavigationProperty | schema_1_1:NavigationProperty | schema_1_2:NavigationProperty">
-@property ( nonatomic , retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> )NSMutableArray *m_<xsl:value-of select="@Name"/>;</xsl:for-each>
+@property ( nonatomic , retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: )NSMutableArray *m_<xsl:value-of select="@Name"/>;</xsl:for-each>
 
 + (id) Create<xsl:value-of select="@Name"/><xsl:if test="schema_1_0:Property[@Nullable = 'false'] | schema_1_1:Property[@Nullable = 'false'] | schema_1_2:Property[@Nullable = 'false']">With<xsl:for-each select="schema_1_0:Property[@Nullable = 'false'] | schema_1_1:Property[@Nullable = 'false'] | schema_1_2:Property[@Nullable = 'false']"><xsl:value-of select="translate(@Name, $uppercase, $smallcase)"/>:(<xsl:if test="@Type = 'Edm.String'">NSString *</xsl:if><xsl:if test="@Type = 'Edm.Int32'">NSNumber *</xsl:if><xsl:if test="@Type = 'Edm.Int16'">NSNumber *</xsl:if><xsl:if test="@Type = 'Edm.Int64'">NSNumber *</xsl:if>
 <xsl:if test="@Type = 'Edm.Binary'">NSData *</xsl:if>
@@ -133,8 +133,8 @@
 	</xsl:for-each>
 }
 
-@property ( nonatomic , retain , getter=getEtag , setter=setEtag )NSString *m_OData_etag;
-<xsl:for-each select="schema_1_0:EntitySet | schema_1_1:EntitySet | schema_1_2:EntitySet">@property ( nonatomic , retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/> ) DataServiceQuery *m_<xsl:value-of select="@Name"/>;
+@property ( nonatomic , retain , getter=getEtag , setter=setEtag: )NSString *m_OData_etag;
+<xsl:for-each select="schema_1_0:EntitySet | schema_1_1:EntitySet | schema_1_2:EntitySet">@property ( nonatomic , retain , getter=get<xsl:value-of select="@Name"/> , setter=set<xsl:value-of select="@Name"/>: ) DataServiceQuery *m_<xsl:value-of select="@Name"/>;
 </xsl:for-each>
 - (id) init;
 - (id) initWithUri:(NSString*)anUri credential:(id)acredential;


### PR DESCRIPTION
@arlobelshee I updated the headers xsl and base classes xsl file in the Framework/bin/ODatagenBinary/MacOSX10.7.sdk/Release directory. I realize these same changes may need to be made elsewhere in the project structure for previous versions. I resolved 2 issues. One issue was incorrect namespaces being applied to base clases and the other was setters not being properly documented with ":" representing the parameter for the setter. I am requesting a pull for these.
